### PR TITLE
UserClaimsFactory to be public

### DIFF
--- a/src/IdentityServer4.AspNetIdentity/Decorator.cs
+++ b/src/IdentityServer4.AspNetIdentity/Decorator.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace IdentityServer4.AspNetIdentity
 {
-    internal class Decorator<TService>
+    public class Decorator<TService>
     {
         public TService Instance { get; set; }
 

--- a/src/IdentityServer4.AspNetIdentity/UserClaimsFactory.cs
+++ b/src/IdentityServer4.AspNetIdentity/UserClaimsFactory.cs
@@ -11,7 +11,7 @@ using IdentityModel;
 
 namespace IdentityServer4.AspNetIdentity
 {
-    internal class UserClaimsFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
+    public class UserClaimsFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
         where TUser : class
     {
         private readonly Decorator<IUserClaimsPrincipalFactory<TUser>> _inner;


### PR DESCRIPTION
Wanting to create custom IUserClaimsPrincipalFactory overriding IdentityServer's default. Cant override if internal.

My requirements for custom IUserClaimsPrincipalFactory is to change ClaimValueType's which are all being returned as string to the value set in the claims database.

Apologies if I have missed any config that removes this need in the first place.