### PR TITLE
Auth Scheme change/fix in ExternalController Callback

### DIFF
--- a/host/Quickstart/Account/ExternalController.cs
+++ b/host/Quickstart/Account/ExternalController.cs
@@ -87,7 +87,7 @@ namespace Host.Quickstart.Account
         public async Task<IActionResult> Callback()
         {
             // read external identity from the temporary cookie
-            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ExternalScheme);
+            var result = await HttpContext.AuthenticateAsync(IdentityServer4.IdentityServerConstants.ExternalCookieAuthenticationScheme);
             if (result?.Succeeded != true)
             {
                 throw new Exception("External authentication error");
@@ -122,7 +122,7 @@ namespace Host.Quickstart.Account
             await HttpContext.SignInAsync(user.Id, name, provider, localSignInProps, additionalLocalClaims.ToArray());
 
             // delete temporary cookie used during external authentication
-            await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+            await HttpContext.SignOutAsync(IdentityServer4.IdentityServerConstants.ExternalCookieAuthenticationScheme);
 
             // validate return URL and redirect back to authorization endpoint or a local page
             var returnUrl = result.Properties.Items["returnUrl"];


### PR DESCRIPTION
In the ExternalController Callback method, changed: 

`Microsoft.AspNetCore.Identity.IdentityConstants.ExternalScheme`
to 
`IdentityServer4.IdentityServerConstants.ExternalCookieAuthenticationScheme`

I verified that the IdentityServer4.Quickstart.UI is the same.