### PR TITLE
Check user active/passive from IPassiveable first on ProfileService.

### DIFF
--- a/src/IdentityServer4.AspNetIdentity.csproj
+++ b/src/IdentityServer4.AspNetIdentity.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityServer4" Version="2.3.0" />
+    <PackageReference Include="IdentityServer4.Storage" Version="2.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.0" />
 
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />

--- a/src/ProfileService.cs
+++ b/src/ProfileService.cs
@@ -5,6 +5,7 @@
 using IdentityServer4.Extensions;
 using IdentityServer4.Models;
 using IdentityServer4.Services;
+using IdentityServer4.Storage.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using System;
@@ -101,6 +102,12 @@ namespace IdentityServer4.AspNetIdentity
             if (user == null)
             {
                 Logger?.LogWarning("No user found matching subject Id: {0}", sub);
+            }
+
+            if (user is IPassiveable passiveable)
+            {
+                context.IsActive = passiveable.Active;
+                return;
             }
 
             context.IsActive = user != null;


### PR DESCRIPTION
Check if the user is active from IPassiveable interface if entity implements it.

AspNetIdentity User entity has no active/passive property but on some scenario you need capability of making user active/passive.

This change depends on the https://github.com/IdentityServer/IdentityServer4.Storage/pull/5 is merged and assumes a NuGet package published with a version number like "2.3.2" (version number can change, the current version for IdentityServer4.Storage is "2.3.1" so I choose the following number), else it won't build.